### PR TITLE
angular-svg-round-progressbar module bump version

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -77,7 +77,7 @@
     <script src="/components/moment/moment.js"></script>
     <script src="/components/angular-moment/angular-moment.js"></script>
     <script src="/components/ng-table/ng-table.js"></script>
-    <script src="/components/angular-svg-round-progressbar/roundProgress.js"></script>
+    <script src="/components/angular-svg-round-progressbar/build/roundProgress.js"></script>
     <!-- endbuild -->
 
     <!-- build:js /scripts/combined.js -->

--- a/web/bower.json
+++ b/web/bower.json
@@ -24,7 +24,7 @@
     "moment": "~2.8.3",
     "angular-moment": "~0.8.2",
     "ng-table": "~0.3.3",
-    "angular-svg-round-progressbar": "master"
+    "angular-svg-round-progressbar": "~0.2.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.0",


### PR DESCRIPTION
On Dec 21, 2014, angular-svg-round-progressbar has bumped to version 0.2.0,
making IRMA's frontend to fail when building. This fix binds the frontend with
a specific version (latest at this time) of this module to avoid this kind of
issues in the future.
