### PR TITLE
[add] Fix non reuploaded files when deleted by cron & tests

### DIFF
--- a/frontend/controllers/filectrl.py
+++ b/frontend/controllers/filectrl.py
@@ -14,10 +14,10 @@
 # terms contained in the LICENSE file.
 
 from frontend.models.sqlobjects import File
-from frontend.helpers.sessions import session_query
+from frontend.helpers.sessions import session_transaction
 
 
 # used by tasks.py
 def remove_files(max_age_sec):
-    with session_query() as session:
+    with session_transaction() as session:
         return File.remove_old_files(max_age_sec, session)

--- a/frontend/controllers/scanctrl.py
+++ b/frontend/controllers/scanctrl.py
@@ -49,7 +49,7 @@ def add_files(scan, files, session):
         try:
             # The file exists
             file_sha256 = hashlib.sha256(data).hexdigest()
-            file = File.load_from_sha256(file_sha256, session)
+            file = File.load_from_sha256(file_sha256, session, data)
         except IrmaDatabaseResultNotFound:
             # It doesn't
             time = compat.timestamp()

--- a/frontend/helpers/utils.py
+++ b/frontend/helpers/utils.py
@@ -14,7 +14,11 @@
 # terms contained in the LICENSE file.
 
 import re
+import os
+
+import config.parser as config
 from lib.common.utils import UUID
+from lib.irma.common.exceptions import IrmaValueError, IrmaFileSystemError
 
 
 def validate_scanid(scanid):
@@ -62,3 +66,47 @@ def guess_hash_type(value):
         except ValueError:
             pass
     return hash_type
+
+
+# helper to split files in subdirs
+def build_sha256_path(sha256):
+    """Builds a file path from its sha256. Creates directory if needed.
+    :param sha256: the sha256 to create path
+    :rtype: string
+    :return: the path build from the sha256
+    :raise: IrmaValueError, IrmaFileSystemError
+        """
+    PREFIX_NB = 3
+    PREFIX_LEN = 2
+    base_path = config.get_samples_storage_path()
+    if (PREFIX_NB * PREFIX_LEN) > len(sha256):
+        raise IrmaValueError("too much prefix for file storage")
+    path = base_path
+    for i in xrange(0, PREFIX_NB):
+        prefix = sha256[i * PREFIX_LEN: (i + 1) * PREFIX_LEN]
+        path = os.path.join(path, prefix)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    if not os.path.isdir(path):
+        reason = "storage path is not a directory"
+        raise IrmaFileSystemError(reason)
+    return os.path.join(path, sha256)
+
+
+def write_sample_on_disk(sha256, data):
+    """Write file data on the location calculated from file sha256
+    :param sha256: the file's sha256
+    :param data: the file's data
+    :rtype: string
+    :return: the path build from the sha256
+    :raise: IrmaFileSystemError
+    """
+    path = build_sha256_path(sha256)
+    try:
+        with open(path, 'wb') as filee:
+            filee.write(data)
+    except IOError:
+        raise IrmaFileSystemError(
+            'Cannot add the sample {0} to the collection'.format(sha256)
+        )
+    return path

--- a/frontend/models/sqlobjects.py
+++ b/frontend/models/sqlobjects.py
@@ -24,13 +24,13 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 import config.parser as config
 from lib.irma.common.exceptions import IrmaDatabaseResultNotFound, \
-    IrmaDatabaseError, IrmaCoreError, IrmaValueError
+    IrmaDatabaseError, IrmaCoreError, IrmaFileSystemError
 from lib.common import compat
 from lib.common.utils import UUID
-from lib.irma.common.exceptions import IrmaFileSystemError
 from lib.irma.common.utils import IrmaScanStatus, IrmaProbeType
 from lib.irma.database.sqlobjects import SQLDatabaseObject
 from frontend.models.nosqlobjects import ProbeRealResult
+from frontend.helpers.utils import write_sample_on_disk
 
 
 # SQLite fix for ForeignKey support
@@ -209,57 +209,39 @@ class File(Base, SQLDatabaseObject):
         return dict((k, v) for (k, v) in self.to_dict().items() if k in keys)
 
     @classmethod
-    def load_from_sha256(cls, sha256, session):
-        """Find the object in the database
+    def load_from_sha256(cls, sha256, session, data=None):
+        """Find the object in the database, update data if file was previously deleted
         :param sha256: the sha256 to look for
         :param session: the session to use
+        :param data: the file's data, in case it was deleted (default is None)
         :rtype: cls
         :return: the object that corresponds to the sha256
-        :raise: IrmaDatabaseResultNotFound, IrmaDatabaseError
+        :raise: IrmaDatabaseResultNotFound, IrmaDatabaseError,
+                IrmaFileSystemError
         """
         try:
-            return session.query(cls).filter(
+            asked_file = session.query(cls).filter(
                 cls.sha256 == sha256
             ).one()
         except NoResultFound as e:
             raise IrmaDatabaseResultNotFound(e)
         except MultipleResultsFound as e:
             raise IrmaDatabaseError(e)
+        if asked_file.path is None and data is not None:
+            asked_file.path = write_sample_on_disk(sha256, data)
+        # Note: nothing is done if path is None and data is None too.
+        #       Further manipulation of *asked_file* may be dangerous
+        return asked_file
 
     def save_file_to_fs(self, data):
         """Add a sample
         :param data: the sample file
         :raise: IrmaFileSystemError if there is a problem with the filesystem
         """
-        # helper to split files in subdirs
-        def build_path(sha256):
-                PREFIX_NB = 3
-                PREFIX_LEN = 2
-                base_path = config.get_samples_storage_path()
-                if (PREFIX_NB * PREFIX_LEN) > len(sha256):
-                    raise IrmaValueError("too much prefix for file storage")
-                path = base_path
-                for i in xrange(0, PREFIX_NB):
-                    prefix = sha256[i * PREFIX_LEN: (i + 1) * PREFIX_LEN]
-                    path = os.path.join(path, prefix)
-                if not os.path.exists(path):
-                    os.makedirs(path)
-                if not os.path.isdir(path):
-                    reason = "storage path is not a directory"
-                    raise IrmaFileSystemError(reason)
-                return os.path.join(path, sha256)
 
         sha256 = hashlib.sha256(data).hexdigest()
         # split files between subdirs
-        path = build_path(sha256)
-        try:
-            with open(path, 'wb') as h:
-                h.write(data)
-        except IOError:
-            raise IrmaFileSystemError(
-                'Cannot add the sample {0} to the collection'.format(sha256)
-            )
-
+        path = write_sample_on_disk(sha256, data)
         self.sha256 = sha256
         self.sha1 = hashlib.sha1(data).hexdigest()
         self.md5 = hashlib.md5(data).hexdigest()
@@ -289,10 +271,11 @@ class File(Base, SQLDatabaseObject):
         """
         fl = session.query(cls).filter(
             cls.timestamp_last_scan < compat.timestamp() - max_age
+        ).filter(
+            cls.path is not None
         ).all()
         for f in fl:
             f.remove_file_from_fs()
-
         return len(fl)
 
     def get_file_names(self):

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+from mock import MagicMock, patch
+
+import frontend.helpers.utils as module
+from lib.irma.common.exceptions import IrmaValueError, IrmaFileSystemError
+
+
+class TestModuleUtils(TestCase):
+
+    def setUp(self):
+        self.old_config = module.config
+        self.old_os = module.os
+        module.config = MagicMock()
+        module.os = MagicMock()
+
+    def tearDown(self):
+        module.config = self.old_config
+        module.os = self.old_os
+
+    def test001_build_sha256_path_ok(self):
+        sha = "1234567890"
+        result = module.build_sha256_path(sha)
+        self.assertTrue(module.config.get_samples_storage_path.called)
+        self.assertEqual(module.os.path.join.call_count, 4)
+        self.assertEqual(module.os.path.exists.call_count, 1)
+        self.assertEqual(module.os.path.join.call_args,
+                         ((module.os.path.join(), sha),))
+        self.assertFalse(module.os.makedirs.called)
+        self.assertEqual(result, module.os.path.join())
+
+    def test002_build_sha256_path_ok_and_path_not_exists(self):
+        sha = "1234567890"
+        module.os.path.exists.return_value = False
+        result = module.build_sha256_path(sha)
+        self.assertTrue(module.config.get_samples_storage_path.called)
+        self.assertEqual(module.os.path.join.call_count, 4)
+        self.assertEqual(module.os.makedirs.call_count, 1)
+        self.assertEqual(module.os.path.exists.call_count, 1)
+        self.assertEqual(module.os.path.join.call_args,
+                         ((module.os.path.join(), sha),))
+        self.assertEqual(result, module.os.path.join())
+
+    def test003_build_sha256_path_raises_IrmaValueError(self):
+        sha = str()
+        with self.assertRaises(IrmaValueError) as context:
+            module.build_sha256_path(sha)
+        self.assertEqual(str(context.exception),
+                         "too much prefix for file storage")
+        self.assertTrue(module.config.get_samples_storage_path.called)
+        self.assertFalse(module.os.path.join.called)
+        self.assertFalse(module.os.path.exists.called)
+        self.assertFalse(module.os.makedirs.called)
+
+    def test004_build_sha256_path_raises_IrmaFileSystemError(self):
+        sha = "1234567890"
+        module.os.path.isdir.return_value = False
+        with self.assertRaises(IrmaFileSystemError) as context:
+            module.build_sha256_path(sha)
+        self.assertEquals(str(context.exception),
+                          "storage path is not a directory")
+        self.assertTrue(module.config.get_samples_storage_path.called)
+        self.assertEqual(module.os.path.join.call_count, 3)
+        self.assertEqual(module.os.path.exists.call_count, 1)
+        self.assertFalse(module.os.makedirs.called)
+
+    def test005_write_sample_on_disk_ok(self):
+        sha, data = "sha_test", "data_test"
+        with patch("%s.build_sha256_path" % module.__name__,
+                   create=True) as mock_build_path:
+            with patch("%s.open" % module.__name__, create=True) as mock_open:
+                result = module.write_sample_on_disk(sha, data)
+        self.assertEqual(mock_build_path.call_count, 1)
+        self.assertEqual(mock_build_path.call_args, ((sha,),))
+        self.assertEqual(mock_open.call_count, 1)
+        self.assertEqual(mock_open.call_args, ((mock_build_path(sha), "wb"),))
+        self.assertEqual(mock_open().__enter__().write.call_count, 1)
+        self.assertEqual(mock_open().__enter__().write.call_args, ((data,),))
+        self.assertEqual(result, mock_build_path(sha))
+
+    def test006_write_sample_on_disk_raises_IrmaFileSystemError(self):
+        sha, data = "sha_test", "data_test"
+        with patch("%s.build_sha256_path" % module.__name__,
+                   create=True) as mock_build_path:
+            with patch("%s.open" % module.__name__, create=True) as mock_open:
+                mock_open().__enter__().write.side_effect = IOError()
+                with self.assertRaises(IrmaFileSystemError) as context:
+                    result = module.write_sample_on_disk(sha, data)
+        expected = "Cannot add the sample {0} to the collection".format(sha)
+        self.assertEqual(str(context.exception),
+                         expected)


### PR DESCRIPTION
Bug fix: code in *frontend/models/sqlobjects.py:remove_file_from_fs* had **self.path = None**, but this wasn't commited (use of **session_query** instead of **sesion_transaction**).

Add: The fonction *frontend/models/sqlobjects.py:load_from_sha256* now can receive an optionnal **data** argument, which rewrite the data on disk if the **File** object linked with the **sha** argument have its **path** property at **None**.