### PR TITLE
Feature api files

### DIFF
--- a/frontend/api/controllers/search.py
+++ b/frontend/api/controllers/search.py
@@ -17,7 +17,7 @@ from bottle import response, request
 
 from frontend.api.errors import process_error
 from frontend.helpers.utils import guess_hash_type
-from frontend.models.sqlobjects import FileWeb
+from frontend.models.sqlobjects import FileWeb, File
 from frontend.helpers.schemas import FileWebSchema
 
 
@@ -78,5 +78,19 @@ def files(db):
             'limit': limit,
             'items': file_web_schema.dump(items, many=True).data,
         }
+    except Exception as e:
+        process_error(e)
+
+
+def get_file(filesha256, db):
+    """Retrieve a file based on its filesha256"""
+    try:
+        fobj = File.load_from_sha256(filesha256, db)
+
+        # Force download
+        response.content_type = 'application/octet-stream; charset=UTF-8'
+        response.content_disposition = 'attachment; filename=' + filesha256
+        return open(fobj.path).read()
+
     except Exception as e:
         process_error(e)

--- a/frontend/api/routes.py
+++ b/frontend/api/routes.py
@@ -26,6 +26,7 @@ def define_routes(application):
     application.route("/probes", callback=probes.list)
     # files routes
     application.route("/search/files", callback=search.files)
+    application.route("/files/<filesha256>", callback=search.get_file)
     # scans routes
     application.route("/scans",
                       callback=scans.list)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -362,6 +362,31 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /files/{fileSHA256}:
+    get:
+      summary: Retrieve a file from its sha256
+      description: |
+        Possibility to get back a file
+      tags:
+        - Search
+      parameters:
+        - name: fileSHA256
+          in: path
+          type: string
+          description: SHA256 of the file
+          required: true
+      responses:
+        200:
+          description: OK
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
 definitions:
   Scan:
     type: object

--- a/swagger/ui/swagger.json
+++ b/swagger/ui/swagger.json
@@ -439,6 +439,34 @@
                 }
             }
         },
+        "/files/{fileSHA256}": {
+            "get": {
+                "summary": "Retrieve a file from its sha256",
+                "description": "Possibility to get back a file\n",
+                "tags": [
+                    "Search"
+                ],
+                "parameters": [
+                    {
+                        "name": "fileSHA256",
+                        "in": "query",
+                        "description": "Hash value (can be md5, sha1 or sha256)",
+                        "type": "string"
+		    }
+		],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+	    }
+	},
         "/search/files": {
             "get": {
                 "summary": "Search files",

--- a/tests/api/data.py
+++ b/tests/api/data.py
@@ -1,6 +1,7 @@
 test_routes = {
     "/probes": ["GET"],
     "/search/files": ["GET"],
+    "/files/<filesha256>": ["GET"],
     "/scans": ["GET", "POST"],
     "/scans/<scanid>": ["GET"],
     "/scans/<scanid>/files": ["POST"],


### PR DESCRIPTION
This PR adds the possibility to retrieve scanned files from their sha256, through `/files/<sha256>`.

The doc has been updated, but as I am not very familiar with technologies used, regression tests still need to be updated.

In addition, it seems that the version of the API (`/opt/irma/irma-frontend/current`, which is a symlink to `releases/20150623...`) in the [VM](http://irma.quarkslab.com/download/1.2.0/irma-1.2.0.vmdk) remained at commit ec772e92